### PR TITLE
Fixes flakey local assertion

### DIFF
--- a/tests/helpers/validate-event.js
+++ b/tests/helpers/validate-event.js
@@ -1,7 +1,7 @@
 import { typeOf } from '@ember/utils';
 
 export default function(assert, now, data, eventType = 'transition') {
-  assert.ok(data.endTime > data.startTime, 'end time is greater than start time');
+  assert.ok(data.endTime >= data.startTime, 'end time is greater than or equal to the start time');
   assert.ok(data.endTime > now, 'end time indicates time has passed since test start');
   assert.ok(data.startTime > now, 'start time indicates time has passed since test start');
   assert.equal(typeOf(data.endTime), 'number', 'endTime is a number');


### PR DESCRIPTION
I kept running into the issue locally where the `data.startTime` and `data.endTime` would be exactly the same in unit test and cause the test suite to randomly fail.

Can we instead test for `>=`?

<img width="805" alt="dummy tests 2018-04-16 20-41-54" src="https://user-images.githubusercontent.com/1318878/38844324-79f1f088-41b8-11e8-83a0-364cb26e14bb.png">
