### PR TITLE
Fix routing bug with QP's

### DIFF
--- a/addon/services/ember-perf.js
+++ b/addon/services/ember-perf.js
@@ -59,7 +59,10 @@ export default Base.extend(Evented, {
       return;
     }
     transitionInfo.promise._emberPerfTransitionId = transitionCounter++;
-    let transitionRoute = transitionInfo.promise.targetName || get(transitionInfo.promise, 'intent.name');
+    let transitionRoute = transitionInfo.promise.targetName ||
+      get(transitionInfo.promise, 'intent.name') ||
+      [...get(transitionInfo.promise, 'state.handlerInfos')].slice(-1)[0].name
+
     let transitionCtxt = get(transitionInfo.promise, 'intent.contexts');
     let hasTransitionCtxt = transitionCtxt && transitionCtxt[0];
     let transitionUrl = get(transitionInfo.promise, 'intent.url');

--- a/tests/acceptance/customization-test.js
+++ b/tests/acceptance/customization-test.js
@@ -85,3 +85,43 @@ test('Initial load, then toggling additional views', function(assert) {
     assert.equal(transitionData.viewData.length, viewsCountWhenEventFired, 'transitionData should not be mutated');
   });
 });
+
+test('Initial load, then refreshing the model via QP', function(assert) {
+  assert.expect(9);
+
+  let dataCount = 0;
+  let lastDestURL;
+
+  application.perfService.on('transitionComplete', (data) => {
+    dataCount++;
+    lastDestURL = data.destURL;
+  });
+
+  visit('/company/1/buildings');
+
+  andThen(function() {
+    assert.equal(dataCount, 1, 'Only one event has been fired for the initial load');
+    assert.equal(currentURL(), '/company/1/buildings', 'We are on the correct initial URL');
+    assert.equal(lastDestURL, '/company/1/buildings', 'We are sending the correct route as a destination');
+  });
+
+  click('.btn-useless-qp');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/company/1/buildings?uselessQP=alpha');
+    assert.equal(dataCount, 2, 'The second event has been recorded for the QP model refresh');
+    assert.equal(lastDestURL, '/company/1/buildings', 'We are sending the correct route as a destination');
+  });
+
+  // This would cause an error to be thrown because there
+  // was no targetName or intent for the transition
+  // see https://github.com/mike-north/ember-perf/issues/22
+  click('.btn-useless-qp');
+  click('.btn-useless-qp');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/company/1/buildings?uselessQP=alpha', 'The URL is correct');
+    assert.equal(dataCount, 4, 'Four events have been fired');
+    assert.equal(lastDestURL, '/company/1/buildings', 'We are sending the correct route as a destination');
+  });
+});

--- a/tests/dummy/app/controllers/company/buildings.js
+++ b/tests/dummy/app/controllers/company/buildings.js
@@ -1,0 +1,11 @@
+import Controller from '@ember/controller';
+
+export default Controller.extend({
+  queryParams: ['uselessQP'],
+
+  actions: {
+    toggleUselessQP() {
+      this.set('uselessQP', this.get('uselessQP') === 'alpha' ? 'beta' : 'alpha');
+    }
+  }
+});

--- a/tests/dummy/app/routes/company/buildings.js
+++ b/tests/dummy/app/routes/company/buildings.js
@@ -10,6 +10,12 @@ const {
 } = Ember;
 
 export default Route.extend({
+  queryParams: {
+    uselessQP: {
+      refreshModel: true
+    }
+  },
+
   model() {
     let buildingIds = get(this.modelFor('company'), 'buildings');
     return randomWait(testing ? 4 : 2400, testing ? 2 : 300).then(() => {

--- a/tests/dummy/app/templates/company/buildings.hbs
+++ b/tests/dummy/app/templates/company/buildings.hbs
@@ -5,5 +5,7 @@
   {{/each}}
 </ul>
 
-
 {{outlet}}
+
+<button class="btn-useless-qp" {{action "toggleUselessQP"}}>Bloop</button>
+


### PR DESCRIPTION
This prevents ember-perf from throwing errors because `transitionRoute` is undefined on `addon/services/ember-perf.js` when the route changes with some query param that is setup with `refreshModel` on the route.

Test and fix for issue reported here: https://github.com/mike-north/ember-perf/issues/22

And one of the cases reported here: https://github.com/mike-north/ember-perf/issues/83