### PR TITLE
Fixes routing bug with same route, different params

### DIFF
--- a/addon/ext/route.js
+++ b/addon/ext/route.js
@@ -1,7 +1,7 @@
 import Mixin from '@ember/object/mixin';
 
 export default Mixin.create({
-  activate() {
+  setupController() {
     this.get('perfService').routeActivated(this);
     this._super(...arguments);
   },

--- a/tests/acceptance/event-body-test.js
+++ b/tests/acceptance/event-body-test.js
@@ -136,6 +136,44 @@ test('Initial load, then drilling in, then pivoting', function(assert) {
   });
 });
 
+test('Nested resource with the same name ', function(assert) {
+  // This test covers the bug here: https://github.com/mike-north/ember-perf/issues/83
+
+  let datas = [];
+  let testStartTime = performanceNow();
+
+  application.perfService.on('transitionComplete', (data) => {
+    datas.push(data);
+  });
+
+  visit('/articles/1');
+
+  andThen(function() {
+    assert.ok(datas, 'Data is present');
+    let [data] = datas;
+    validateEvent(assert, testStartTime, data);
+    assert.equal(datas.length, 1, 'Only one event fired');
+  });
+
+  click('a[href=\'/articles/2\']');
+
+  andThen(function() {
+    assert.equal(datas.length, 2, 'Only two events fired');
+    let data = datas[datas.length - 1];
+    assert.equal(data.destURL, '/articles/2', 'Intent URL is correct');
+    assert.equal(data.destRoute, 'articles.article', 'Intent route is correct');
+  });
+
+  click('a[href=\'/articles/3\']');
+
+  andThen(function() {
+    assert.equal(datas.length, 3, 'Only three events fired');
+    let data = datas[datas.length - 1];
+    assert.equal(data.destURL, '/articles/3', 'Intent URL is correct');
+    assert.equal(data.destRoute, 'articles.article', 'Intent route is correct');
+  });
+});
+
 test('Initial measureRender', function(assert) {
   let datas = [];
   let testStartTime = performanceNow();

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,9 @@ const Router = EmberRouter.extend({
 });
 
 Router.map(function() {
+  this.route('articles', function() {
+    this.route('article', { path: ':article_id' });
+  });
   this.route('companies', function() {
     this.route('info');
   });

--- a/tests/dummy/app/routes/articles/article.js
+++ b/tests/dummy/app/routes/articles/article.js
@@ -1,0 +1,4 @@
+// import Ember from 'ember';
+import BaseRoute from '../base';
+
+export default BaseRoute.extend({ });

--- a/tests/dummy/app/routes/base.js
+++ b/tests/dummy/app/routes/base.js
@@ -1,5 +1,8 @@
+import Object from '@ember/object';
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-
+  model(params) {
+    return Object.create({id: params.article_id});
+  }
 });

--- a/tests/dummy/app/templates/articles/article.hbs
+++ b/tests/dummy/app/templates/articles/article.hbs
@@ -1,0 +1,9 @@
+<h1>Availible Articles</h1>
+
+<ul>
+  <li>{{#link-to 'articles.article' '1'}}Article 1{{/link-to}}</li>
+  <li>{{#link-to 'articles.article' '2'}}Article 2{{/link-to}}</li>
+  <li>{{#link-to 'articles.article' '3'}}Article 3{{/link-to}}</li>
+</ul>
+
+<h2>Article {{model.id}}</h2>

--- a/tests/helpers/validate-event.js
+++ b/tests/helpers/validate-event.js
@@ -12,7 +12,17 @@ export default function(assert, now, data, eventType = 'transition') {
 
   if (eventType === 'transition') {
     assert.equal(typeOf(data.routes), 'array', 'data.routes is an array');
-    assert.deepEqual(data.routes.map((r) => r.name), ['application', 'loading', 'company', 'company.loading', 'company.buildings'], 'Proper routes load');
+
+
+    let rs = data.routes.map((r) => r.name)
+
+    if (rs.includes('articles')) {
+      assert.deepEqual(rs, ['application', 'articles', 'articles.article'], 'Proper routes load for articles resource');
+
+    } else {
+      assert.deepEqual(rs, ['application', 'loading', 'company', 'company.loading', 'company.buildings'], 'Proper routes load for companies/buildings resource');
+    }
+
     assert.equal(data.routes
       .map((r) => r.startTime)
       .filter((x) => typeOf(x) !== 'number'), 0, 'All route startTimes are numbers');


### PR DESCRIPTION
Fixes the bug 

> The first one is thrown when transitioning between routes with the same name but different params (e.g. from /articles/1 to /articles/2). The error is:

Originally outlined here: https://github.com/mike-north/ember-perf/issues/83

(This build will fail until rebased on top of https://github.com/mike-north/ember-perf/pull/146)

First commit:
<img width="817" alt="dummy tests 2018-04-17 12-11-19" src="https://user-images.githubusercontent.com/1318878/38885710-8078dfda-4239-11e8-8353-a399c6d312d4.png">

Second commit:
<img width="403" alt="monosnap 2018-04-17 12-13-12" src="https://user-images.githubusercontent.com/1318878/38885718-86412a6c-4239-11e8-847f-903801ad3c62.png">
